### PR TITLE
bus reset for KL25Z fix, USBSerial update

### DIFF
--- a/features/unsupported/USBDevice/USBDevice/USBHAL_KL25Z.cpp
+++ b/features/unsupported/USBDevice/USBDevice/USBHAL_KL25Z.cpp
@@ -455,6 +455,9 @@ void USBHAL::usbisr(void) {
         USB0->ERREN   =  0xFF;  // enable error interrupt sources
         USB0->ADDR    =  0x00;  // set default address
 
+        // reset bus for USBDevice layer
+        busReset();
+
         return;
     }
 

--- a/features/unsupported/USBDevice/USBSerial/USBCDC.cpp
+++ b/features/unsupported/USBDevice/USBSerial/USBCDC.cpp
@@ -38,6 +38,10 @@ USBCDC::USBCDC(uint16_t vendor_id, uint16_t product_id, uint16_t product_release
     USBDevice::connect(connect_blocking);
 }
 
+void USBCDC::USBCallback_busReset(void) {
+    terminal_connected = false;
+};
+
 bool USBCDC::USBCallback_request(void) {
     /* Called in ISR context */
 

--- a/features/unsupported/USBDevice/USBSerial/USBCDC.h
+++ b/features/unsupported/USBDevice/USBSerial/USBCDC.h
@@ -116,6 +116,7 @@ protected:
     virtual bool USBCallback_request();
     virtual void USBCallback_requestCompleted(uint8_t *buf, uint32_t length);
     virtual bool USBCallback_setConfiguration(uint8_t configuration);
+    virtual void USBCallback_busReset(void);
     volatile bool terminal_connected;
 
 };

--- a/features/unsupported/USBDevice/USBSerial/USBSerial.cpp
+++ b/features/unsupported/USBDevice/USBSerial/USBSerial.cpp
@@ -66,3 +66,7 @@ bool USBSerial::EPBULK_OUT_callback() {
 uint8_t USBSerial::available() {
     return buf.available();
 }
+
+bool USBSerial::connected() {
+    return terminal_connected;
+}

--- a/features/unsupported/USBDevice/USBSerial/USBSerial.h
+++ b/features/unsupported/USBDevice/USBSerial/USBSerial.h
@@ -83,6 +83,13 @@ public:
     */
     uint8_t available();
 
+     /**
+    * Check if the terminal is connected.
+    *
+    * @returns connection status
+    */
+    bool connected();
+
     /** Determine if there is a character available to read
      *
      *  @returns


### PR DESCRIPTION
1. added call to busReset() to KL25Z HAL; now the USB stack survives if you disconnect the cable, similar to LPC40 
2. busReset callback to update terminal_connected in USBCDC 
3. new bool USBSerial::connected() to read protected terminal_connected property, useful when you want to check if the terminal is ready from main app

